### PR TITLE
pumaの設定ファイル内のパスを正しく修正

### DIFF
--- a/server/config/puma.rb
+++ b/server/config/puma.rb
@@ -16,7 +16,7 @@ worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
 # port ENV.fetch('PORT') { 3020 }
-bind "unix:///var/www/pllizm/server/tmp/sockets/puma.sock"
+bind "unix:///var/www/pllizm-api/server/tmp/sockets/puma.sock"
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
pumaの設定ファイル内のパスが誤っていたため、正しいパスに修正した。